### PR TITLE
Find reference assemblies automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bin/
 **/*.dll
 **/*.exe
 **/*.exe.mdb
+**/*.vsix
+.assemblies.json

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -16,7 +16,7 @@
     {
       "modifiers": [
         {
-          "exclude": [ ".git/**", "obj/**", "bin/**", "*.dll", "out.il" ]
+          "exclude": [ ".git/**", "obj/**", "bin/**", "*.dll", "out.il", ".assemblies.json" ]
         }
       ]
     }

--- a/ghul-console.ghulproj
+++ b/ghul-console.ghulproj
@@ -6,13 +6,29 @@
 
   <Target Name="CreateManifestResourceNames" />
 
+  <!-- FIXME: is this just duplicating the AssemblyReferenceCache and, if so, how am I supposed to consum that? -->
+  <Target Name="GhulAssembliesJson" AfterTargets="CoreCompile" DependsOnTargets="FindReferenceAssembliesForReferences">
+      <PropertyGroup>
+          <Assemblies>{"assemblies": [@(ReferencePathWithRefAssemblies -> '"%(fullpath)"', ',')]}</Assemblies>
+      </PropertyGroup>
+
+      <WriteLinesToFile
+          File=".assemblies.json"
+          Lines="$(Assemblies)"
+          Overwrite="true"
+          Encoding="Utf-8" />
+
+      <Message Importance="high" Text="updated $(OutputFile) with referenced assemblies" />
+
+  </Target>  
+
   <Target Name="CoreCompile">
 
     <ItemGroup>
       <GhulSources Include="src/**/*.ghul" />
     </ItemGroup>
 
-    <Exec Command="ghul --v3 @(GhulSources) -o $(IntermediateOutputPath)$(AssemblyName).dll" />
+    <Exec Command="ghul --v3 @(GhulSources) -o $(IntermediateOutputPath)$(AssemblyName).dll @(ReferencePathWithRefAssemblies -> '--assembly %(fullpath)', '%20')" />
 
     <Copy SourceFiles="$(ProjectDir)$(IntermediateOutputPath)$(AssemblyName).dll" DestinationFolder="$(ProjectDir)$(IntermediateOutputPath)ref" />   
   </Target>

--- a/ghul.json
+++ b/ghul.json
@@ -1,6 +1,5 @@
 {
     "want_plaintext_hover": true,
-    "other_flags": "--v3",
     "source": [
         "src"
     ]

--- a/src/ghul-console.ghul
+++ b/src/ghul-console.ghul
@@ -6,7 +6,7 @@ namespace Program is
         entry() static is
             @IL.entrypoint()
 
-            Std.error.write_line("Hello world");
+            Std.error.write_line("Hello world");          
 
             return;
         si


### PR DESCRIPTION
Add MSBuild target to .ghulproj that copies the list of reference assemblies onto the compiler command line and also into a JSON file where it can be read by the VSCE and passed into the compiler when running in analysis mode.

This enables access to the whole .NET SDK and any NuGet packages referenced from the project file without any explicit `--assembly` command line arguments 